### PR TITLE
gunicorn logformat

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,11 @@ init_db() {
 
 start_api() {
     # start server
-    exec gunicorn -w 4 -b 0.0.0.0:5000 --access-logfile - --error-logfile - "thupoll.app_factory:init_app()"
+    exec gunicorn -w 4 -b 0.0.0.0:5000 \
+      --access-logfile - \
+      --error-logfile - \
+      --access-logformat "%(h)s %(l)s %(u)s %(t)s pid %(p)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\" %(l)s %(D)s µs" \
+      "thupoll.app_factory:init_app()"
 }
 
 # Start specified service


### PR DESCRIPTION
Вместо
```
172.21.0.1 - - [16/May/2019:17:45:28 +0000] "GET /ping HTTP/1.1" 200 4 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.131 Safari/537.36"
```

Будет
```
172.21.0.1 - - [16/May/2019:17:41:21 +0000] pid <15> "GET /ping HTTP/1.1" 200 4 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.131 Safari/537.36" - 495 µs
```